### PR TITLE
Fixed JS event receiving for not implemented event types

### DIFF
--- a/src/js/OTPublisher.coffee
+++ b/src/js/OTPublisher.coffee
@@ -66,7 +66,7 @@ class TBPublisher
   setSession: (session) =>
     @session = session
   eventReceived: (response) =>
-    @[response.eventType](response.data)
+    @[response.eventType]?(response.data)
   streamCreated: (event) =>
     @stream = new TBStream( event.stream, @session.sessionConnected )
     streamEvent = new TBEvent("streamCreated")

--- a/src/js/OTSession.coffee
+++ b/src/js/OTSession.coffee
@@ -168,7 +168,7 @@ class TBSession
   # event listeners
   # todo - other events: connectionCreated, connectionDestroyed, signal?, streamPropertyChanged, signal:type?
   eventReceived: (response) =>
-    @[response.eventType](response.data)
+    @[response.eventType]?(response.data)
   connectionCreated: (event) =>
     connection = new TBConnection( event.connection )
     connectionEvent = new TBEvent("connectionCreated")

--- a/src/js/OTSubscriber.coffee
+++ b/src/js/OTSubscriber.coffee
@@ -84,7 +84,7 @@ class TBSubscriber
     Cordova.exec(@eventReceived, TBSuccess, OTPlugin, "addEvent", ["subscriberEvents"] )
     OT.updateViews()
   eventReceived: (response) =>
-    @[response.eventType](response.data)
+    @[response.eventType]?(response.data)
   connected: (event) =>
     streamEvent = new TBEvent("connected")
     streamEvent.stream = event.streamId

--- a/www/opentok.js
+++ b/www/opentok.js
@@ -393,7 +393,8 @@ TBPublisher = (function() {
   };
 
   TBPublisher.prototype.eventReceived = function(response) {
-    return this[response.eventType](response.data);
+    var _name;
+    return typeof this[_name = response.eventType] === "function" ? this[_name](response.data) : void 0;
   };
 
   TBPublisher.prototype.streamCreated = function(event) {
@@ -763,7 +764,8 @@ TBSession = (function() {
   };
 
   TBSession.prototype.eventReceived = function(response) {
-    return this[response.eventType](response.data);
+    var _name;
+    return typeof this[_name = response.eventType] === "function" ? this[_name](response.data) : void 0;
   };
 
   TBSession.prototype.connectionCreated = function(event) {
@@ -1067,7 +1069,8 @@ TBSubscriber = (function() {
   }
 
   TBSubscriber.prototype.eventReceived = function(response) {
-    return this[response.eventType](response.data);
+    var _name;
+    return typeof this[_name = response.eventType] === "function" ? this[_name](response.data) : void 0;
   };
 
   TBSubscriber.prototype.connected = function(event) {


### PR DESCRIPTION
Fixes the following JS issue:

> Uncaught TypeError: this[response.eventType] is not a function TypeError: this[response.eventType] is not a function at TBSubscriber.eventReceived (file:///android_asset/www/index.html:4604:36) at file:///android_asset/www/index.html:4483:59 at Object.callbackFromNative (file:///android_asset/www/cordova.js:287:58) at <anonymous>:1:9 URL: file:///android_asset/www/cordova.js

Some events do not have a handler function implemented, so we have to check if they do before we call them.