### PR TITLE
SAN-5607 Bump Opentok SDK -> 2.17

### DIFF
--- a/build-extras.gradle
+++ b/build-extras.gradle
@@ -18,5 +18,5 @@ allprojects {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.opentok.android:opentok-android-sdk:2.15.3'
+    implementation 'com.opentok.android:opentok-android-sdk:2.17.2'
 } 

--- a/scripts/downloadiOSSDK.js
+++ b/scripts/downloadiOSSDK.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 module.exports = function (context) {
-    var IosSDKVersion = "OpenTok-iOS-2.15.3";
+    var IosSDKVersion = "OpenTok-iOS-2.17.1";
     var downloadFile = require('./downloadFile.js'),
         exec = require('./exec/exec.js'),
         Q = require('q'),

--- a/src/android/OpenTokAndroidPlugin.java
+++ b/src/android/OpenTokAndroidPlugin.java
@@ -989,7 +989,7 @@ public class OpenTokAndroidPlugin extends CordovaPlugin
                     params.put("partner_id", apiKey);
                     params.put("payload", payload.toString());
                     params.put("source", "https://github.com/opentok/cordova-plugin-opentok");
-                    params.put("build", "2.15.3");
+                    params.put("build", "2.17.2");
                     params.put("session_id", sessionId);
                     if (connectionId != null) {
                         params.put("action", "cp_on_connect");

--- a/src/ios/OpenTokPlugin.m
+++ b/src/ios/OpenTokPlugin.m
@@ -57,7 +57,7 @@
     [payload setObject:@"3.4.3" forKey:@"cp_version"];
     NSMutableDictionary *logData = [[NSMutableDictionary alloc]init];
     [logData setObject:apiKey forKey:@"partner_id"];
-    [logData setObject:@"2.15.3" forKey:@"build"];
+    [logData setObject:@"2.17.1" forKey:@"build"];
     [logData setObject:@"https://github.com/opentok/cordova-plugin-opentok" forKey:@"source"];
     [logData setObject:@"info" forKey:@"payload_type"];
     [logData setObject:payload forKey:@"payload"];


### PR DESCRIPTION
Tested on both platforms and didn't notice any issues. A few of the methods deprecated in this update are used by the plugin, but we don't appear to be explicitly calling any of them, and they still work for now.

iOS Release Notes: https://tokbox.com/developer/sdks/ios/release-notes.html
Android Release Notes: https://tokbox.com/developer/sdks/android/release-notes.html 